### PR TITLE
NES-2817 Jenkins on AWS Take 2

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -11,3 +11,30 @@ To update the region map execute the following lines in your terminal:
 $ regions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output text)
 $ for region in $regions; do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20191116.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
+## Deploying
+
+1. Deploy the VPC
+    The VPC is a dependency of the Jenkins stack.
+
+    aws cloudformation deploy \
+        --capabilities CAPABILITY_IAM \
+        --profile <IAM_USER_PROFILE> \
+        --s3-bucket "unmanaged-cf-templates-templates-<ACCOUNT_ID>" \
+        --stack-name "<NAME_OF_THE_VPC_STACK>" \
+        --template-file "./../vpc/vpc-2azs.yaml" \
+
+2. Then we can finally deploy the Jenkins stack
+
+    aws cloudformation deploy
+        --capabilities CAPABILITY_IAM
+        --parameter-overrides
+            AgentEnableMetrics="<true|false>"
+            CIDRWhiteList="$(dig +short myip.opendns.com @resolver1.opendns.com)/32"
+            KeyName="spargo-control"
+            MasterAdminPassword="admin_password"
+            MasterEnableMetrics="true"
+            ParentVPCStack="<NAME_OF_THE_VPC_STACK>"
+        --profile <IAM_USER_PROFILE>
+        --s3-bucket "unmanaged-cf-templates-templates-<ACCOUNT_ID>"
+        --stack-name "<NAME_OF_THE_JENKINS_STACK>"
+        --template-file "./jenkins2-ha-agents.yaml"

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -14,27 +14,28 @@ $ for region in $regions; do ami=$(aws --region $region ec2 describe-images --fi
 ## Deploying
 
 1. Deploy the VPC
-    The VPC is a dependency of the Jenkins stack.
+The VPC is a dependency of the Jenkins stack.
 
     aws cloudformation deploy \
-        --capabilities CAPABILITY_IAM \
         --profile <IAM_USER_PROFILE> \
-        --s3-bucket "unmanaged-cf-templates-templates-<ACCOUNT_ID>" \
+        --capabilities CAPABILITY_IAM \
+        --s3-bucket "unmanaged-cf-templates-<ACCOUNT_ID>" \
         --stack-name "<NAME_OF_THE_VPC_STACK>" \
         --template-file "./../vpc/vpc-2azs.yaml" \
 
-2. Then we can finally deploy the Jenkins stack
+2. Deploy the Jenkins stack.
+*Note*: this will set the CIDR whitelist to the current public IPv4 address of the workstation where the `aws cloudformation deploy` is run.
 
-    aws cloudformation deploy
-        --capabilities CAPABILITY_IAM
-        --parameter-overrides
-            AgentEnableMetrics="<true|false>"
-            CIDRWhiteList="$(dig +short myip.opendns.com @resolver1.opendns.com)/32"
-            KeyName="spargo-control"
-            MasterAdminPassword="admin_password"
-            MasterEnableMetrics="true"
-            ParentVPCStack="<NAME_OF_THE_VPC_STACK>"
-        --profile <IAM_USER_PROFILE>
-        --s3-bucket "unmanaged-cf-templates-templates-<ACCOUNT_ID>"
-        --stack-name "<NAME_OF_THE_JENKINS_STACK>"
+    aws cloudformation deploy \
+        --profile <IAM_USER_PROFILE> \
+        --capabilities CAPABILITY_IAM \
+        --parameter-overrides \
+            AgentEnableMetrics="<true|false>" \
+            CIDRWhiteList="$(dig +short myip.opendns.com @resolver1.opendns.com)/32" \
+            KeyName="<SSH_KEYPAIR_NAME>" \
+            MasterAdminPassword="admin_password" \
+            MasterEnableMetrics="true" \
+            ParentVPCStack="<NAME_OF_THE_VPC_STACK>" \
+        --s3-bucket "unmanaged-cf-templates-templates-<ACCOUNT_ID>" \
+        --stack-name "<NAME_OF_THE_JENKINS_STACK>" \
         --template-file "./jenkins2-ha-agents.yaml"

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -127,9 +127,9 @@ Parameters:
     - 'internet-facing'
     - internal
   MasterInstanceType:
-    Description: 'The instance type of the Jenkins master.'
+    Description: 'The instance type of the Jenkins master. t2.micro works but t3.medium is better.'
     Type: String
-    Default: 't3.medium'
+    Default: 't2.micro'
   MasterAdminPassword:
     Description: 'A password for the Jenkins master admin. Must not be changed!'
     Type: String
@@ -167,9 +167,9 @@ Parameters:
     - Public
     - Private
   AgentInstanceType:
-    Description: 'The instance type of the Jenkins agents.'
+    Description: 'The instance type of the Jenkins agents. t2.micro works but t3.medium or c5.large work better.'
     Type: String
-    Default: 't3.medium'
+    Default: 't2.micro'
   AgentVolumeSize:
     Description: 'The root volume size, in Gibibytes (GiB). Keep in mind that Jenkins home lives on EFS.'
     Type: Number

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -64,6 +64,10 @@ Metadata:
         default: 'Security'
       Parameters:
       - CIDRWhiteList
+    - Label:
+        default: 'Jenkins'
+      Parameters:
+      - JenkinsPackage
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -213,10 +217,13 @@ Parameters:
     Type: String
     Default: 'cron(0 5 ? * * *)'
   CIDRWhiteList:
-    # TODO: Add some validation here.
     Description: 'A whitelist of CIRD ranges which will be allowed to access Jenkins.'
-    AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
+    # AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
     Type: String
+  JenkinsPackage:
+    Description: 'The name of the package to install from this list: https://pkg.jenkins.io/redhat-stable/'
+    Type: String
+    Default: 'jenkins-2.190.3-1.1.noarch.rpm'
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -895,6 +902,7 @@ Resources:
           packages:
             rpm:
               jenkins: 'https://pkg.jenkins.io/redhat-stable/jenkins-2.190.3-1.1.noarch.rpm'
+              jenkins: !Join [ "/", ['https://pkg.jenkins.io/redhat-stable', !Ref JenkinsPackage ] ]
             yum:
               'java-1.8.0-amazon-corretto': []
               'ruby': []
@@ -1317,7 +1325,7 @@ Resources:
         Value: 'jenkins-master'
         PropagateAtLaunch: true
       MetricsCollection:
-        Granularity: 1Minute
+      - Granularity: 1Minute
     CreationPolicy:
       ResourceSignal:
         Timeout: PT15M
@@ -2028,7 +2036,7 @@ Resources:
         Value: 'jenkins-agent'
         PropagateAtLaunch: true
       MetricsCollection:
-        Granularity: 1Minute
+      - Granularity: 1Minute
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -1316,6 +1316,8 @@ Resources:
       - Key: Name
         Value: 'jenkins-master'
         PropagateAtLaunch: true
+      MetricsCollection:
+        Granularity: 1Minute
     CreationPolicy:
       ResourceSignal:
         Timeout: PT15M

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -215,6 +215,7 @@ Parameters:
   CIDRWhiteList:
     # TODO: Add some validation here.
     Description: 'A whitelist of CIRD ranges which will be allowed to access Jenkins.'
+    AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
     Type: String
 Mappings:
   RegionMap:
@@ -371,7 +372,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
-      CidrIp: '${CIDRWhiteList}'
+      CidrIp: !Ref CIDRWhiteList
   MasterELBSGInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -123,7 +123,7 @@ Parameters:
   MasterInstanceType:
     Description: 'The instance type of the Jenkins master.'
     Type: String
-    Default: 't2.micro'
+    Default: 't3.medium'
   MasterAdminPassword:
     Description: 'A password for the Jenkins master admin. Must not be changed!'
     Type: String
@@ -158,7 +158,7 @@ Parameters:
   AgentInstanceType:
     Description: 'The instance type of the Jenkins agents.'
     Type: String
-    Default: 't2.micro'
+    Default: 't3.medium'
   AgentVolumeSize:
     Description: 'The root volume size, in Gibibytes (GiB). Keep in mind that Jenkins home lives on EFS.'
     Type: Number

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -217,13 +217,13 @@ Parameters:
     Type: String
     Default: 'cron(0 5 ? * * *)'
   CIDRWhiteList:
-    Description: 'A whitelist of CIRD ranges which will be allowed to access Jenkins.'
+    Description: 'A whitelist of CIDR ranges which will be allowed to access Jenkins.'
     # AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
     Type: String
   JenkinsPackage:
     Description: 'The name of the package to install from this list: https://pkg.jenkins.io/redhat-stable/'
     Type: String
-    Default: 'jenkins-2.190.3-1.1.noarch.rpm'
+    Default: 'jenkins-2.204.1-1.1.noarch.rpm'
 Mappings:
   RegionMap:
     'eu-north-1':

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -50,6 +50,7 @@ Metadata:
       - MasterLogsRetentionInDays
       - MasterVolumeSize
       - MasterLoadBalancerIdleTimeout
+      - MasterEnableMetrics
     - Label:
         default: 'Agent Parameters'
       Parameters:
@@ -60,6 +61,7 @@ Metadata:
       - AgentMinSize
       - AgentMaxBuildWaitTimeInSeconds
       - AgentLogsRetentionInDays
+      - AgentEnableMetrics
     - Label:
         default: 'Security'
       Parameters:
@@ -152,6 +154,11 @@ Parameters:
     Default: 60
     MinValue: 1
     MaxValue: 4000
+  MasterEnableMetrics:
+    Description: 'Should the master have Group Metrics collection enabled?'
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
   AgentSubnetsReach:
     Description: 'Should the agents have direct access to the Internet or do you prefer private subnets with NAT?'
     Type: String
@@ -194,6 +201,11 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  AgentEnableMetrics:
+    Description: 'Should the slave have Group Metrics collection enabled?'
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
@@ -281,6 +293,8 @@ Conditions:
   HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
   HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
   HasEFSBackupRetentionPeriod: !Not [!Equals [!Ref EFSBackupRetentionPeriod, 0]]
+  HasMasterMetrics: !Equals [!Ref MasterEnableMetrics, "true"]
+  HasAgentMetrics: !Equals [!Ref AgentEnableMetrics, "true"]
 Resources:
   MasterStorageSG:
     Type: 'AWS::EC2::SecurityGroup'
@@ -1324,8 +1338,11 @@ Resources:
       - Key: Name
         Value: 'jenkins-master'
         PropagateAtLaunch: true
-      MetricsCollection:
-      - Granularity: 1Minute
+      MetricsCollection: 
+        - Fn::If:
+          - HasMasterMetrics
+          - Granularity: 1Minute
+          - !Ref 'AWS::NoValue'
     CreationPolicy:
       ResourceSignal:
         Timeout: PT15M
@@ -2035,8 +2052,11 @@ Resources:
       - Key: Name
         Value: 'jenkins-agent'
         PropagateAtLaunch: true
-      MetricsCollection:
-      - Granularity: 1Minute
+      MetricsCollection: 
+        - Fn::If:
+          - HasAgentMetrics
+          - Granularity: 1Minute
+          - !Ref 'AWS::NoValue'
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -60,6 +60,10 @@ Metadata:
       - AgentMinSize
       - AgentMaxBuildWaitTimeInSeconds
       - AgentLogsRetentionInDays
+    - Label:
+        default: 'Security'
+      Parameters:
+      - CIDRWhiteList
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -208,6 +212,10 @@ Parameters:
     Description: 'A CRON expression specifying when AWS Backup initiates a backup job.'
     Type: String
     Default: 'cron(0 5 ? * * *)'
+  CIDRWhiteList:
+    # TODO: Add some validation here.
+    Description: 'A whitelist of CIRD ranges which will be allowed to access Jenkins.'
+    Type: String
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -363,7 +371,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
-      CidrIp: '0.0.0.0/0'
+      CidrIp: '${CIDRWhiteList}'
   MasterELBSGInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -2027,6 +2027,8 @@ Resources:
       - Key: Name
         Value: 'jenkins-agent'
         PropagateAtLaunch: true
+      MetricsCollection:
+        Granularity: 1Minute
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFS=$'\n\t'
+
+#####
+# TODO
+#       + Validate
+#       + Destroy
+#####
+
+# See: http://wiki.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+export PS5='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+# Absolute path to current dir.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+declare vpc_stack_name="jenkins-vpc"
+
+_usage() {
+    echo "USAGE:"
+    echo -e "\tAWS_PROFILE=my_aws_profile_name $1"
+}
+
+_generate_ssh_key() {
+    : # ssh-keygen -t rsa -b 4096 -C "spargo-aws-control@spargoinc.com"
+}
+
+declare AWS_PROFILE=${AWS_PROFILE:-}
+if [[ -z $AWS_PROFILE ]]; then
+    echo "You must specify your AWS profile name"
+    echo "See: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html"
+    _usage
+    exit 255
+fi
+echo "Using AWS profile ${AWS_PROFILE}"
+
+_get_account_id() {
+    aws sts \
+        get-caller-identity \
+            --query Account \
+            --output text
+}
+
+# Create s3 bucket if it doesn't exist.
+# This bucket will hold our templates so that CloudFormation can execute them.
+# You can't omit the bucket using CLI because the template size exceeds the limit set by AWS CLI (51,200 bytes), so uploading works best if you want to do this via terminal.
+_ensure_s3_bucket() {
+    local account_id
+    local bucket_name
+
+    bucket_name="jenkins-cf-templates-$(_get_account_id)"
+
+    aws s3 ls s3://${bucket_name} > /dev/nul 2>&1 || aws s3 mb s3://${bucket_name} > /dev/nul 2>&1
+    echo "${bucket_name}"
+}
+
+# Deploy VPC
+_cf_deploy_vpc() {
+    local bucket=$1
+
+    set -x
+    # Create the VPC structure.
+#    (
+        aws cloudformation deploy \
+            --template-file "${HERE}/../vpc/vpc-2azs.yaml" \
+            --capabilities CAPABILITY_IAM \
+            --s3-bucket $bucket \
+            --stack-name ${vpc_stack_name} # > /dev/null & \
+#    ) && watch \
+#        "aws cloudformation describe-stack-events \
+#            --stack-name $vpc_stack_name | \
+#                jq -r '.StackEvents[] |
+#                        \"\\(.Timestamp | sub(\"\\\\.[0-9]+Z$\"; \"Z\") | fromdate | strftime(\"%H:%M:%S\") ) \\(.LogicalResourceId) \\(.ResourceType) \\(.ResourceStatus)\"
+#                ' | column -t"
+    set +x
+}
+
+_get_my_ip() {
+    dig +short myip.opendns.com @resolver1.opendns.com
+}
+
+# Deploy all other Jenkins resources (EC2, ELB, etc).
+_cf_deploy_jenkins() {
+    local bucket=$1
+    local stack="jenkins-resources"
+
+    set -x
+    #####
+    # TODO:
+    #   These arguments must be inspected before the task is complete.
+    #####
+    # Create all other Jenkins resources.
+    # Credits for watching events as the occur: https://advancedweb.hu/cloudformation-cli-workflows/#deploy-and-watch-the-events
+#    (
+        aws cloudformation deploy \
+            --template-file "${HERE}/jenkins2-ha-agents.yaml" \
+            --capabilities CAPABILITY_IAM \
+            --s3-bucket $bucket \
+            --parameter-overrides \
+            CIDRWhiteList="$(_get_my_ip)/32" \
+                KeyName="spargo-control" \
+                MasterAdminPassword="mypassword" \
+                ParentVPCStack="${vpc_stack_name}" \
+            --stack-name $stack # > /dev/null & \
+#    ) && watch \
+#        "aws cloudformation describe-stack-events \
+#            --stack-name $stack | \
+#                jq -r '.StackEvents[] |
+#                        \"\\(.Timestamp | sub(\"\\\\.[0-9]+Z$\"; \"Z\") | fromdate | strftime(\"%H:%M:%S\") ) \\(.LogicalResourceId) \\(.ResourceType) \\(.ResourceStatus)\"
+#                ' | column -t"
+    set +x
+}
+
+main() {
+    local bucket_name
+
+    # echo "Creating #3 bucket if it doesnt exist..."
+    # bucket_name="$(_ensure_s3_bucket)"
+    # echo "S3 bucket '${bucket_name} created."
+
+    bucket_name="jenkins-cf-templates-***REMOVED***"
+
+    # echo "Deploying VPC"
+    # _cf_deploy_vpc ${bucket_name}
+
+    echo "Deploying all Jenkins resources"
+    _cf_deploy_jenkins ${bucket_name}
+}
+
+main $@
+exit $?

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -116,10 +116,8 @@ main() {
     local bucket_name
 
     # echo "Creating #3 bucket if it doesnt exist..."
-    # bucket_name="$(_ensure_s3_bucket)"
+    bucket_name="$(_ensure_s3_bucket)"
     # echo "S3 bucket '${bucket_name} created."
-
-    bucket_name="jenkins-cf-templates-***REMOVED***"
 
     # echo "Deploying VPC"
     # _cf_deploy_vpc ${bucket_name}


### PR DESCRIPTION
Changes:
1. EC2 instances advice for master and slaves have been added. We started with `t3.medium` instead of `t2.micro` because it makes everything faster and more robust.
2. User can specify Jenkins version to be installed.
3. CIDR whitelist is user provided and has only one CIDR block in template
2. Make master/slave `MetricsCollection` toggle-able

